### PR TITLE
Upgrade to `dhall-to-json@1.2.7`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF505
 RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" > /etc/apt/sources.list.d/mongodb-org-3.6.list
 RUN apt-get update
 RUN apt-get install -y mongodb-org-tools mongodb-org-shell
-RUN curl -LO https://github.com/dhall-lang/dhall-haskell/releases/download/1.20.1/dhall-json-1.20.1-x86_64-linux.tar.bz2 && \
-  tar -xf dhall-json-1.20.1-x86_64-linux.tar.bz2 && \
+RUN curl -LO https://github.com/dhall-lang/dhall-haskell/releases/download/1.21.0/dhall-json-1.2.7-x86_64-linux.tar.bz2 && \
+  tar -xf dhall-json-1.2.7-x86_64-linux.tar.bz2 && \
   mv ./bin/dhall-to-json /usr/bin


### PR DESCRIPTION
This PR upgrades the version of `dhall-to-json` used by GitLab CI in the **app** to prevent integrity checks failures for hashes generated according to the language standard v6.0.0.

See https://gitlab.in.fretlink.com/fretlink/app/-/jobs/38874.

Those hashes are desirables because they’ll remain stable during future standard versions upgrades.