### PR TITLE
Remove jessie updates from apt sources list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
 RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" > /etc/apt/sources.list.d/mongodb-org-3.6.list
-RUN apt-get update
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list && apt-get update
 RUN apt-get install -y mongodb-org-tools mongodb-org-shell
 RUN curl -LO https://github.com/dhall-lang/dhall-haskell/releases/download/1.21.0/dhall-json-1.2.7-x86_64-linux.tar.bz2 && \
   tar -xf dhall-json-1.2.7-x86_64-linux.tar.bz2 && \


### PR DESCRIPTION
Jessie was [archived](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html) recently so updates aren’t available anymore and `apt-get update` fails with the following messages:

> W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

> E: Some index files failed to download. They have been ignored, or old ones used instead.

Removing the `deb http://deb.debian.org/debian jessie-updates main` line from `/etc/apt/sources.list` seems to solve the issue.

I thought basing the image on `node:8.12.0-stretch` or `node:8.16.0` (the latest version of the ‘Carbon’ Node.js LTS is already based on stretch according to [Docker Hub](https://hub.docker.com/_/node)) would also work but `mongodb-org-{shell,tools}` complain about unmet dependencies:

> mongodb-org-shell : Depends: libssl1.0.0 (>= 1.0.1) but it is not installable
> mongodb-org-tools : Depends: libssl1.0.0 (>= 1.0.1) but it is not installable
